### PR TITLE
docs: add README video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ YouTube Downloader is a browser extension built for users who need a cleaner way
 - Use a browser-native download flow instead of manual extraction
 - Preserve a cleaner workflow for long-form and short-form content
 
-## Watch The Video
-
-<a href="https://www.youtube.com/watch?v=l5oJwqxB4Gk" target="_blank">
-<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/youtube-downloader-save-videos-before-they-disappear.jpg" width="700px">
-</a>
-
 ## Links
 
 - :rocket: Get it here: [YouTube Downloader](https://serp.ly/youtube-downloader)
@@ -26,7 +20,9 @@ YouTube Downloader is a browser extension built for users who need a cleaner way
 
 ## Preview
 
-![YouTube Downloader workflow preview](https://raw.githubusercontent.com/serpapps/youtube-downloader/refs/heads/main/assets/workflow-preview.webp)
+<a href="https://www.youtube.com/watch?v=l5oJwqxB4Gk" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/youtube-downloader-save-videos-before-they-disappear.jpg" width="700px">
+</a>
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ YouTube Downloader is a browser extension built for users who need a cleaner way
 - Use a browser-native download flow instead of manual extraction
 - Preserve a cleaner workflow for long-form and short-form content
 
+## Watch The Video
+
+<a href="https://www.youtube.com/watch?v=l5oJwqxB4Gk" target="_blank">
+<img src="https://raw.githubusercontent.com/devinschumacher/uploads/refs/heads/main/images/youtube-downloader-save-videos-before-they-disappear.jpg" width="700px">
+</a>
+
 ## Links
 
 - :rocket: Get it here: [YouTube Downloader](https://serp.ly/youtube-downloader)
@@ -20,7 +26,7 @@ YouTube Downloader is a browser extension built for users who need a cleaner way
 
 ## Preview
 
-![YouTube Downloader workflow preview](assets/workflow-preview.webp)
+![YouTube Downloader workflow preview](https://raw.githubusercontent.com/serpapps/youtube-downloader/refs/heads/main/assets/workflow-preview.webp)
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- Adds the Watch The Video README section from the reviewed dry-run file
- Converts local README image references to raw GitHub URLs where applicable

## Notes
- This PR was created from the local dry-run README preview.
- No force push was used.
